### PR TITLE
(part viii) accelerated collisions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (NOT raylib_FOUND) # If there's none, fetch and build raylib
     endif ()
 endif ()
 
-set(FLECS_VERSION 4.0.5)
+set(FLECS_VERSION 4.1.0)
 find_package(flecs ${FLECS_VERSION} QUIET) # QUIET or REQUIRED
 if (NOT flecs_FOUND) # If there's none, fetch and build flecs
     include(FetchContent)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -67,7 +67,7 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
     m_world.import<debug::DebugModule>();
     m_world.import<tilemap::TilemapModule>();
 
-    m_world.set<core::GameSettings>({
+     m_world.set<core::GameSettings>({
         m_windowName,
         m_windowWidth,
         m_windowHeight,
@@ -75,6 +75,7 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
         m_windowHeight
     });
     m_world.add<physics::CollisionRecordList>();
+    m_world.set<physics::SpatialHashingGrid>({48, {0,0}});
 
     flecs::entity player = m_world.entity("player")
             .set<core::Tag>({"player"})

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -120,7 +120,7 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
             })
             .set<gameplay::Split>({std::unordered_set<int>()})
             .set<gameplay::Bounce>({2})
-            .set<gameplay::Damage>({0})
+            .set<gameplay::Damage>({2})
             .set<physics::Velocity2D>({0, 0})
             .set<physics::Collider>({
                 false,
@@ -183,11 +183,11 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
     m_world.entity("enemy_spawner")
             .set<gameplay::Spawner>({enemy});
 
-    // m_world.entity("tilemap_1")
-    //         .set<tilemap::Tilemap>({
-    //             "../resources/tiled/maps/sampleMap.tmx",
-    //             3.0f
-    //         });
+    m_world.entity("tilemap_1")
+            .set<tilemap::Tilemap>({
+                "../resources/tiled/maps/sampleMap.tmx",
+                3.0f
+            });
 
     m_world.set<rendering::TrackingCamera>({
         player,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -75,7 +75,7 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
         m_windowHeight
     });
     m_world.add<physics::CollisionRecordList>();
-    m_world.set<physics::SpatialHashingGrid>({640, {0,0}});
+    m_world.set<physics::SpatialHashingGrid>({48, {0,0}});
 
     flecs::entity player = m_world.entity("player")
             .set<core::Tag>({"player"})

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -75,7 +75,7 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
         m_windowHeight
     });
     m_world.add<physics::CollisionRecordList>();
-    m_world.set<physics::SpatialHashingGrid>({48, {0,0}});
+    m_world.set<physics::SpatialHashingGrid>({640, {0,0}});
 
     flecs::entity player = m_world.entity("player")
             .set<core::Tag>({"player"})
@@ -120,7 +120,7 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
             })
             .set<gameplay::Split>({std::unordered_set<int>()})
             .set<gameplay::Bounce>({2})
-            .set<gameplay::Damage>({2})
+            .set<gameplay::Damage>({0})
             .set<physics::Velocity2D>({0, 0})
             .set<physics::Collider>({
                 false,
@@ -183,11 +183,11 @@ Game::Game(const char *windowName, int windowWidth, int windowHeight) : m_world(
     m_world.entity("enemy_spawner")
             .set<gameplay::Spawner>({enemy});
 
-    m_world.entity("tilemap_1")
-            .set<tilemap::Tilemap>({
-                "../resources/tiled/maps/sampleMap.tmx",
-                3.0f
-            });
+    // m_world.entity("tilemap_1")
+    //         .set<tilemap::Tilemap>({
+    //             "../resources/tiled/maps/sampleMap.tmx",
+    //             3.0f
+    //         });
 
     m_world.set<rendering::TrackingCamera>({
         player,

--- a/src/modules/ai/systems/follow_target_system.h
+++ b/src/modules/ai/systems/follow_target_system.h
@@ -19,7 +19,7 @@ namespace ai::systems {
                               physics::DesiredVelocity2D &velocity) {
         const flecs::entity target = it.pair(3).second(); // target component
         if (target.id() == 0) return;
-        const Vector2 dir = Vector2Normalize(target.get<core::Position2D>()->value - position.value);
+        const Vector2 dir = Vector2Normalize(target.get<core::Position2D>().value - position.value);
         velocity.value = dir * speed.value;
     }
 }

--- a/src/modules/ai/systems/stop_when_arrived_at_target_system.h
+++ b/src/modules/ai/systems/stop_when_arrived_at_target_system.h
@@ -20,7 +20,7 @@ namespace ai::systems {
                               physics::DesiredVelocity2D &velocity) {
         const flecs::entity target = it.pair(3).second(); // target component
         if (target.id() == 0) return;
-        const Vector2 ab = target.get<core::Position2D>()->value - pos.value;
+        const Vector2 ab = target.get<core::Position2D>().value - pos.value;
 
         // using the squared length is faster computationally
         const float distSquared = Vector2LengthSqr(ab);

--- a/src/modules/debug/debug_module.cpp
+++ b/src/modules/debug/debug_module.cpp
@@ -81,6 +81,22 @@ namespace debug {
                 .kind<rendering::RenderGizmos>()
                 .run(systems::debug_closest_enemy_to_player_system);
         debug_closest_enemy.disable();
+
+            grid_cell_grow = world.system<physics::SpatialHashingGrid>()
+            .kind(0)
+            .each([] (flecs::entity e, physics::SpatialHashingGrid& grid) {
+                    grid.cell_size = grid.cell_size + 16;
+                    e.set<physics::SpatialHashingGrid>({grid});
+            });
+            grid_cell_grow.disable();
+
+            grid_cell_shrink = world.system<physics::SpatialHashingGrid>()
+            .kind(0)
+            .each([] (flecs::entity e, physics::SpatialHashingGrid& grid) {
+                    grid.cell_size = std::max(16, grid.cell_size - 16);
+                    e.set<physics::SpatialHashingGrid>({grid});
+            });
+            grid_cell_shrink.disable();
     }
 
     void DebugModule::register_entities(flecs::world &world) {
@@ -123,5 +139,17 @@ namespace debug {
                     .set<rendering::gui::MenuBarTabItem>({
                         "Toggle Hashing Collisions", physics::m_collision_detection_spatial_hashing_system, rendering::gui::TOGGLE
                     });
+            world.entity("debug_collisions_item_9").child_of(dropdown)
+                   .set<rendering::gui::MenuBarTabItem>({
+                       "Toggle Hashing Collisions ECS", physics::m_collision_detection_spatial_ecs, rendering::gui::TOGGLE
+                   });
+            world.entity("debug_collisions_item_10").child_of(dropdown)
+                   .set<rendering::gui::MenuBarTabItem>({
+                       "Grow Cell Size", grid_cell_grow, rendering::gui::RUN
+                   });
+            world.entity("debug_collisions_item_11").child_of(dropdown)
+                   .set<rendering::gui::MenuBarTabItem>({
+                       "Shrink Cell Size", grid_cell_shrink, rendering::gui::RUN
+                   });
     }
 }

--- a/src/modules/debug/debug_module.cpp
+++ b/src/modules/debug/debug_module.cpp
@@ -14,6 +14,7 @@
 #include "modules/engine/rendering/gui/gui_module.h"
 #include <raymath.h>
 
+#include "modules/engine/physics/physics_module.h"
 #include "systems/debug_closest_enemy_to_player_system.h"
 #include "systems/debug_collidable_entities_system.h"
 #include "systems/debug_colliders_system.h"
@@ -69,9 +70,11 @@ namespace debug {
                 .run(systems::debug_mouse_position_system);
         debug_mouse_pos.disable();
 
-        debug_grid = world.system("Draw Grid")
+        debug_grid = world.system<rendering::TrackingCamera, physics::SpatialHashingGrid, physics::GridCell>("Draw Grid")
+                .term_at(0).singleton()
+                .term_at(1).singleton()
                 .kind<rendering::RenderGizmos>()
-                .run(systems::debug_grid_system);
+                .each(systems::debug_grid_system);
         debug_grid.disable();
 
         debug_closest_enemy = world.system("Draw Ray to closest target")
@@ -113,5 +116,12 @@ namespace debug {
                 .set<rendering::gui::MenuBarTabItem>({
                     "Toggle View Closest Enemy", debug_closest_enemy, rendering::gui::TOGGLE
                 });
+
+            world.entity("debug_collisions_item_7").child_of(dropdown)
+                .set<rendering::gui::MenuBarTabItem>({"Toggle Naive Collisions", physics::m_collision_detection_naive_system, rendering::gui::TOGGLE});
+            world.entity("debug_collisions_item_8").child_of(dropdown)
+                    .set<rendering::gui::MenuBarTabItem>({
+                        "Toggle Hashing Collisions", physics::m_collision_detection_spatial_hashing_system, rendering::gui::TOGGLE
+                    });
     }
 }

--- a/src/modules/debug/debug_module.h
+++ b/src/modules/debug/debug_module.h
@@ -24,6 +24,9 @@ namespace debug {
         flecs::system debug_grid;
         flecs::system debug_closest_enemy;
 
+        flecs::system grid_cell_grow;
+        flecs::system grid_cell_shrink;
+
         void register_components(flecs::world& world);
 
         void register_systems(flecs::world& world);

--- a/src/modules/debug/systems/debug_closest_enemy_to_player_system.h
+++ b/src/modules/debug/systems/debug_closest_enemy_to_player_system.h
@@ -17,18 +17,18 @@ namespace debug::systems {
         auto player = iter.world().lookup("player");
         auto pos = player.get<core::Position2D>();
         float shortest_distance_sqr = 10000000;
-        core::Position2D target_pos{pos->value};
+        core::Position2D target_pos{pos.value};
         core::queries::position_and_tag_query.each([&](const core::Position2D &other_pos, const core::Tag &tag) {
             if ("enemy" != tag.name) return;
-            float d = Vector2DistanceSqr(pos->value, other_pos.value);
+            float d = Vector2DistanceSqr(pos.value, other_pos.value);
             if (d > shortest_distance_sqr) return;
             shortest_distance_sqr = d;
             target_pos = other_pos;
         });
 
-        if (target_pos.value == pos->value) return;
+        if (target_pos.value == pos.value) return;
 
-        DrawLineEx(Vector2{pos->value.x, pos->value.y}, Vector2{target_pos.value.x, target_pos.value.y}, 1,
+        DrawLineEx(Vector2{pos.value.x, pos.value.y}, Vector2{target_pos.value.x, target_pos.value.y}, 1,
                    GREEN);
     }
 }

--- a/src/modules/debug/systems/debug_grid_system.h
+++ b/src/modules/debug/systems/debug_grid_system.h
@@ -9,8 +9,8 @@
 #include <raylib.h>
 
 namespace debug::systems {
-    inline void debug_grid_system(flecs::iter &iter) {
-        GuiGrid({0, 0, (float) GetScreenWidth(), (float) GetScreenHeight()}, "grid", 48, 1, nullptr);
+    inline void debug_grid_system(rendering::TrackingCamera &camera, physics::SpatialHashingGrid& grid, physics::GridCell& cell) {
+        DrawRectangleLines(grid.offset.x + cell.x * grid.cell_size, grid.offset.y +cell.y * grid.cell_size, grid.cell_size, grid.cell_size, ORANGE);
     }
 }
 #endif //DEBUG_GRID_SYSTEM_H

--- a/src/modules/engine/core/components.h
+++ b/src/modules/engine/core/components.h
@@ -20,8 +20,8 @@ namespace core {
         std::string windowName;
         int initialWidth;
         int initialHeight;
-        int windowWidth;
-        int windowHeight;
+        int window_width;
+        int window_height;
     };
 
     struct Tag {

--- a/src/modules/engine/core/core_module.h
+++ b/src/modules/engine/core/core_module.h
@@ -16,6 +16,7 @@ namespace core {
     public:
         // do not add anything to the constructor, instead change the base class
         CoreModule(flecs::world& world): BaseModule(world) {}
+        GameSettings* game_settings;
     private:
         void register_components(flecs::world &world);
 

--- a/src/modules/engine/physics/components.h
+++ b/src/modules/engine/physics/components.h
@@ -8,8 +8,6 @@
 #include <vector>
 
 namespace physics {
-    struct CircleCollider;
-    struct BoxCollider;
 
     enum CollisionFilter {
         none = 0x00,
@@ -80,11 +78,7 @@ namespace physics {
         std::size_t operator () (const std::pair<long,long>& h) const {
             auto h1 = std::hash<long>{}(h.first);
             auto h2 = std::hash<long>{}(h.second);
-
-            // A common way to combine hashes is to use XOR and a bit shift.
-            // The choice of shift value can impact distribution, but 0x9e3779b9 is a common
-            // constant derived from the golden ratio, used in boost::hash_combine.
-            return h1 ^ (h2 << 1); // Or h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2)); for better distribution
+            return h1 ^ (h2 << 1);
         }
     };
 
@@ -93,6 +87,20 @@ namespace physics {
         std::vector<SignificantCollisionRecord> significant_collisions;
         std::unordered_map<std::pair<long,long>, CollisionInfo, IdPairHash> collisions_info;
     };
+
+    struct SpatialHashingGrid {
+        int cell_size;
+        Vector2 offset;
+        std::unordered_map<std::pair<long,long>, flecs::entity, IdPairHash> cells;
+    };
+
+    struct GridCell {
+        int x;
+        int y;
+        std::vector<flecs::entity> entities;
+    };
+
+    struct ContainedIn {};
 
 
 }

--- a/src/modules/engine/physics/physics_module.cpp
+++ b/src/modules/engine/physics/physics_module.cpp
@@ -17,9 +17,15 @@
 #include "modules/engine/rendering/components.h"
 #include "systems/add_collided_with_system.h"
 #include "systems/collision_cleanup_system.h"
+#include "systems/collision_detection_relationship_spatial_hashing_system.h"
+#include "systems/collision_detection_spatial_hashing_system.h"
 #include "systems/collision_detection_system.h"
 #include "systems/collision_resolution_system.h"
+#include "systems/init_spatial_hashing_grid_system.h"
 #include "systems/reset_desired_velocity_system.h"
+#include "systems/update_cell_entities_system.h"
+#include "systems/update_grid_on_window_resized_system.h"
+#include "systems/update_grid_system.h"
 #include "systems/update_position_system.h"
 #include "systems/update_velocity_system.h"
 
@@ -28,9 +34,7 @@ namespace physics {
         world.component<Velocity2D>();
         world.component<AccelerationSpeed>();
         world.component<CollidedWith>();
-        world.component<ContainedIn>().add(flecs::Exclusive).add(flecs::DontFragment);
-        //world.component<CircleCollider>().is_a<Collider>();
-        //world.component<BoxCollider>().is_a<Collider>();
+        world.component<ContainedIn>().add(flecs::Exclusive);
     }
 
     void PhysicsModule::register_queries(flecs::world &world) {
@@ -40,7 +44,6 @@ namespace physics {
         queries::box_collider_query = world.query_builder<core::Position2D, Collider>().with<BoxCollider>().build();
     }
 
-
     void PhysicsModule::register_systems(flecs::world &world) {
         m_physicsTick = world.timer().interval(PHYSICS_TICK_LENGTH);
 
@@ -48,67 +51,25 @@ namespace physics {
                 .term_at(0).singleton()
                 .term_at(1).singleton()
                 .kind(flecs::OnStart)
-                .each([](flecs::iter &it, size_t i, SpatialHashingGrid &hashing_grid, core::GameSettings &settings) {
-                    m_cell_query.clear();
-                    for (int y = -1; y < std::ceil((float) settings.window_height / (float) hashing_grid.cell_size) + 1;
-                         y++) {
-                        for (int x = -1; x < std::ceil(settings.window_width / hashing_grid.cell_size) + 1; x++) {
-                            flecs::entity e = it.world().entity().set<GridCell>({x, y});
-                            hashing_grid.cells[std::make_pair(x, y)] = e;
-                        }
-                    }
-                });
+                .each(systems::init_spatial_hashing_grid_system);
 
         world.system<SpatialHashingGrid, core::GameSettings>("update grid on window resized")
                 .term_at(0).singleton()
                 .term_at(1).singleton()
                 .kind(flecs::OnUpdate)
-                .each([](flecs::iter &it, size_t i, SpatialHashingGrid &hashing_grid, core::GameSettings &settings) {
-                    if (IsWindowResized()) {
-                        for (auto cell: hashing_grid.cells) {
-                            cell.second.destruct();
-                        }
-                        hashing_grid.cells.clear();
-                        for (int y = -1; y < std::ceil((float) settings.window_height / (float) hashing_grid.cell_size)+ 1; y++) {
-                            for (int x = -1; x < std::ceil(settings.window_width / hashing_grid.cell_size) + 1; x++) {
-                                flecs::entity e = it.world().entity().set<GridCell>({x, y});
-                                hashing_grid.cells[std::make_pair(x, y)] = e;
-                            }
-                        }
-                    }
-                });
+                .each(systems::update_grid_on_window_resized_system);
 
         world.observer<SpatialHashingGrid, core::GameSettings>("update grid on grid set")
                 .term_at(1).singleton()
                 .event(flecs::OnSet)
-                .each([](flecs::iter &it, size_t i, SpatialHashingGrid &hashing_grid, core::GameSettings &settings) {
-                    for (auto cell: hashing_grid.cells) {
-                        cell.second.destruct();
-                    }
-                    hashing_grid.cells.clear();
-                    m_cell_query.clear();
-                    for (int y = -1; y < std::ceil((float) settings.window_height / (float) hashing_grid.cell_size)+ 1; y++) {
-                            for (int x = -1; x < std::ceil(settings.window_width / hashing_grid.cell_size) + 1; x++) {
-                                flecs::entity e = it.world().entity().set<GridCell>({x, y});
-                                hashing_grid.cells[std::make_pair(x, y)] = e;
-                            }
-                        }
-                    std::cout << "Updating Grid" << std::endl;
-                });
+                .each(systems::reset_grid);
 
         world.system<SpatialHashingGrid, rendering::TrackingCamera, core::GameSettings, GridCell>("update grid")
                 .term_at(0).singleton()
                 .term_at(1).singleton()
                 .term_at(2).singleton()
                 .kind(flecs::PreUpdate)
-                .each([](flecs::iter &it, size_t i, SpatialHashingGrid &grid, rendering::TrackingCamera &cam,
-                         core::GameSettings &settings, GridCell &cell) {
-                    grid.offset = cam.camera.target - Vector2{
-                                      settings.window_width / 2.0f, settings.window_height / 2.0f
-                                  };
-
-                    cell.entities.clear();
-                });
+                .each(systems::update_grid_system);
 
 
         world.system<const Velocity2D, DesiredVelocity2D>("reset desired vel")
@@ -133,18 +94,7 @@ namespace physics {
                 .term_at(0).singleton()
                 .without<StaticCollider>()
                 .kind<UpdateBodies>()
-                .each([](flecs::entity e, SpatialHashingGrid &grid, Collider &col, core::Position2D &pos) {
-                    int cell_pos_x = std::floor((pos.value.x - grid.offset.x) / grid.cell_size);
-                    int cell_pos_y = std::floor((pos.value.y - grid.offset.y) / grid.cell_size);
-
-                    if (!grid.cells.contains(std::make_pair(cell_pos_x, cell_pos_y))) {
-                        return;
-                    }
-
-                    flecs::entity cell = grid.cells[std::make_pair(cell_pos_x, cell_pos_y)];
-                    cell.get_mut<GridCell>().entities.push_back(e);
-                    //e.add<ContainedIn>(cell);
-                });
+                .each(systems::update_cell_entities_system);
 
 
         m_collision_detection_naive_system = world.system<CollisionRecordList, const core::Position2D, const Collider>(
@@ -174,54 +124,7 @@ namespace physics {
                 .kind<Detection>()
                 .multi_threaded()
                 .tick_source(m_physicsTick)
-                .each([](flecs::entity e, CollisionRecordList &list, SpatialHashingGrid &grid, GridCell &cell) {
-                    std::vector<CollisionRecord> collisions;
-                    for (int offset_y = -1; offset_y <= 1; offset_y++) {
-                        for (int offset_x = -1; offset_x <= 1; offset_x++) {
-                            int x = cell.x + offset_x;
-                            int y = cell.y + offset_y;
-                            if (!grid.cells.contains(std::make_pair(x, y))) continue;
-
-                            const GridCell neighbour = grid.cells[std::make_pair(x, y)].get<GridCell>();
-
-                            for (int i = 0; i < cell.entities.size(); i++) {
-                                flecs::entity self = cell.entities[i];
-                                if (!self.is_alive()) continue;
-                                const core::Position2D pos = cell.entities[i].get<core::Position2D>();
-                                const Collider collider = cell.entities[i].get<Collider>();
-                                for (int j = 0; j < neighbour.entities.size(); j++) {
-                                    flecs::entity other = neighbour.entities[j];
-                                    if (!other.is_alive()) continue;
-                                    const core::Position2D other_pos = neighbour.entities[j].get<core::Position2D>();
-                                    const Collider other_collider = neighbour.entities[j].get<Collider>();
-                                    if (self.id() <= other.id()) continue;
-
-                                    if ((collider.collision_filter & other_collider.collision_type) == none) continue;
-
-                                    Rectangle self_rec = {
-                                        pos.value.x + collider.bounds.x, pos.value.y + collider.bounds.y,
-                                        collider.bounds.width,
-                                        collider.bounds.height
-                                    };
-                                    Rectangle other_rec = {
-                                        other_pos.value.x + other_collider.bounds.x,
-                                        other_pos.value.y + other_collider.bounds.y,
-                                        other_collider.bounds.width, other_collider.bounds.height
-                                    };
-
-                                    if (CheckCollisionRecs(self_rec, other_rec)) {
-                                        //std::cout << "Collision detected" << std::endl;
-                                        collisions.push_back({self, other});
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    if (collisions.empty()) return;
-                    systems::list_mutex.lock();
-                    list.records.insert(list.records.end(), collisions.begin(), collisions.end());
-                    systems::list_mutex.unlock();
-                });
+                .each(systems::collision_detection_spatial_hashing_system);
         m_collision_detection_spatial_hashing_system.disable();
 
         m_collision_detection_spatial_ecs = world.system<CollisionRecordList, SpatialHashingGrid, GridCell>(
@@ -229,58 +132,9 @@ namespace physics {
                 .term_at(0).singleton()
                 .term_at(1).singleton()
                 .kind<Detection>()
-                //.multi_threaded()
+                .multi_threaded()
                 .tick_source(m_physicsTick)
-                .each([](flecs::iter &it, size_t i, CollisionRecordList &list, SpatialHashingGrid &grid,
-                         GridCell &cell) {
-                    flecs::entity current_cell = it.entity(i);
-
-                    std::vector<CollisionRecord> collisions;
-                    for (int offset_y = -1; offset_y <= 1; offset_y++) {
-                        for (int offset_x = -1; offset_x <= 1; offset_x++) {
-                            int x = cell.x + offset_x;
-                            int y = cell.y + offset_y;
-                            if (!grid.cells.contains(std::make_pair(x, y))) continue;
-
-                            auto pair = std::make_pair(x, y);
-                            flecs::entity neighbour_cell = grid.cells[pair];
-
-
-                            m_cell_query[std::make_pair(cell.x, cell.y)].each([&](
-                            flecs::iter &self_it, size_t self_i, const core::Position2D &pos,
-                            const Collider &collider) {
-                                    flecs::entity self = self_it.entity(self_i);
-                                    m_cell_query[pair].each([&](flecs::iter &other_it, size_t other_i,
-                                                                const core::Position2D &other_pos,
-                                                                const Collider &other_collider) {
-                                        flecs::entity other = other_it.entity(other_i);
-                                        if (other.id() <= self.id()) return;
-
-                                        if ((collider.collision_filter & other_collider.collision_type) == none) return;
-
-                                        Rectangle self_rec = {
-                                            pos.value.x + collider.bounds.x, pos.value.y + collider.bounds.y,
-                                            collider.bounds.width,
-                                            collider.bounds.height
-                                        };
-                                        Rectangle other_rec = {
-                                            other_pos.value.x + other_collider.bounds.x,
-                                            other_pos.value.y + other_collider.bounds.y,
-                                            other_collider.bounds.width, other_collider.bounds.height
-                                        };
-
-                                        if (CheckCollisionRecs(self_rec, other_rec)) {
-                                            collisions.push_back({self, other});
-                                        }
-                                    });
-                                });
-                        }
-                    }
-                    if (collisions.empty()) return;
-                    systems::list_mutex.lock();
-                    list.records.insert(list.records.end(), collisions.begin(), collisions.end());
-                    systems::list_mutex.unlock();
-                });
+                .each(systems::collision_detection_relationship_spatial_hashing_system);
         m_collision_detection_spatial_ecs.disable();
 
         world.system<CollisionRecordList>("Collision Resolution ECS (Naive Record List)")

--- a/src/modules/engine/physics/physics_module.cpp
+++ b/src/modules/engine/physics/physics_module.cpp
@@ -142,7 +142,7 @@ namespace physics {
                     }
 
                     flecs::entity cell = grid.cells[std::make_pair(cell_pos_x, cell_pos_y)];
-                    cell.get_mut<GridCell>()->entities.push_back(e);
+                    cell.get_mut<GridCell>().entities.push_back(e);
                     //e.add<ContainedIn>(cell);
                 });
 
@@ -182,31 +182,31 @@ namespace physics {
                             int y = cell.y + offset_y;
                             if (!grid.cells.contains(std::make_pair(x, y))) continue;
 
-                            const GridCell *neighbour = grid.cells[std::make_pair(x, y)].get<GridCell>();
+                            const GridCell neighbour = grid.cells[std::make_pair(x, y)].get<GridCell>();
 
                             for (int i = 0; i < cell.entities.size(); i++) {
                                 flecs::entity self = cell.entities[i];
                                 if (!self.is_alive()) continue;
-                                const core::Position2D *pos = cell.entities[i].get<core::Position2D>();
-                                const Collider *collider = cell.entities[i].get<Collider>();
-                                for (int j = 0; j < neighbour->entities.size(); j++) {
-                                    flecs::entity other = neighbour->entities[j];
+                                const core::Position2D pos = cell.entities[i].get<core::Position2D>();
+                                const Collider collider = cell.entities[i].get<Collider>();
+                                for (int j = 0; j < neighbour.entities.size(); j++) {
+                                    flecs::entity other = neighbour.entities[j];
                                     if (!other.is_alive()) continue;
-                                    const core::Position2D *other_pos = neighbour->entities[j].get<core::Position2D>();
-                                    const Collider *other_collider = neighbour->entities[j].get<Collider>();
+                                    const core::Position2D other_pos = neighbour.entities[j].get<core::Position2D>();
+                                    const Collider other_collider = neighbour.entities[j].get<Collider>();
                                     if (self.id() <= other.id()) continue;
 
-                                    if ((collider->collision_filter & other_collider->collision_type) == none) continue;
+                                    if ((collider.collision_filter & other_collider.collision_type) == none) continue;
 
                                     Rectangle self_rec = {
-                                        pos->value.x + collider->bounds.x, pos->value.y + collider->bounds.y,
-                                        collider->bounds.width,
-                                        collider->bounds.height
+                                        pos.value.x + collider.bounds.x, pos.value.y + collider.bounds.y,
+                                        collider.bounds.width,
+                                        collider.bounds.height
                                     };
                                     Rectangle other_rec = {
-                                        other_pos->value.x + other_collider->bounds.x,
-                                        other_pos->value.y + other_collider->bounds.y,
-                                        other_collider->bounds.width, other_collider->bounds.height
+                                        other_pos.value.x + other_collider.bounds.x,
+                                        other_pos.value.y + other_collider.bounds.y,
+                                        other_collider.bounds.width, other_collider.bounds.height
                                     };
 
                                     if (CheckCollisionRecs(self_rec, other_rec)) {

--- a/src/modules/engine/physics/physics_module.cpp
+++ b/src/modules/engine/physics/physics_module.cpp
@@ -28,7 +28,7 @@ namespace physics {
         world.component<Velocity2D>();
         world.component<AccelerationSpeed>();
         world.component<CollidedWith>();
-        world.component<ContainedIn>().add(flecs::Exclusive);
+        world.component<ContainedIn>().add(flecs::Exclusive).add(flecs::DontFragment);
         //world.component<CircleCollider>().is_a<Collider>();
         //world.component<BoxCollider>().is_a<Collider>();
     }

--- a/src/modules/engine/physics/physics_module.h
+++ b/src/modules/engine/physics/physics_module.h
@@ -25,6 +25,8 @@ namespace physics {
     static CollisionFilter enemy_filter = static_cast<CollisionFilter>(player | enemy | environment);
     static CollisionFilter environment_filter = static_cast<CollisionFilter>(player | enemy);
 
+    inline flecs::system m_collision_detection_spatial_hashing_system;
+    inline flecs::system m_collision_detection_naive_system;
 
     class PhysicsModule : public BaseModule<PhysicsModule> {
         friend class BaseModule<PhysicsModule>;
@@ -114,6 +116,7 @@ namespace physics {
         }
 
         flecs::entity m_physicsTick;
+
 
     private:
         void register_components(flecs::world &world);

--- a/src/modules/engine/physics/physics_module.h
+++ b/src/modules/engine/physics/physics_module.h
@@ -26,7 +26,10 @@ namespace physics {
     static CollisionFilter environment_filter = static_cast<CollisionFilter>(player | enemy);
 
     inline flecs::system m_collision_detection_spatial_hashing_system;
+    inline flecs::system m_collision_detection_spatial_ecs;
     inline flecs::system m_collision_detection_naive_system;
+
+    inline std::unordered_map<std::pair<long,long>, flecs::query<const core::Position2D, const Collider>, IdPairHash> m_cell_query;
 
     class PhysicsModule : public BaseModule<PhysicsModule> {
         friend class BaseModule<PhysicsModule>;

--- a/src/modules/engine/physics/physics_module.h
+++ b/src/modules/engine/physics/physics_module.h
@@ -39,12 +39,12 @@ namespace physics {
         PhysicsModule(flecs::world &world): BaseModule(world) {
         };
 
-        static Vector2 collide_circles(const CircleCollider *a, const core::Position2D *a_pos, CollisionInfo& a_info,
-                                       const CircleCollider *b, const core::Position2D *b_pos, CollisionInfo& b_info) {
-            float combinedRadius = a->radius + b->radius;
+        static Vector2 collide_circles(const CircleCollider &a, const core::Position2D &a_pos, CollisionInfo& a_info,
+                                       const CircleCollider &b, const core::Position2D &b_pos, CollisionInfo& b_info) {
+            float combinedRadius = a.radius + b.radius;
 
             // Find the distance and adjust to resolve the overlap
-            Vector2 direction = b_pos->value - a_pos->value;
+            Vector2 direction = b_pos.value - a_pos.value;
             Vector2 moveDirection = Vector2Normalize(direction);
             float overlap = combinedRadius - Vector2Length(direction);
 
@@ -54,29 +54,29 @@ namespace physics {
             return moveDirection * overlap;
         }
 
-        static Vector2 collide_circle_rec(const CircleCollider *a, core::Position2D *a_pos, CollisionInfo& a_info,
-                                          const Collider *b, core::Position2D *b_pos, CollisionInfo& b_info) {
-            float recCenterX = b_pos->value.x + b->bounds.x + b->bounds.width / 2.0f;
-            float recCenterY = b_pos->value.y + b->bounds.y + b->bounds.height / 2.0f;
+        static Vector2 collide_circle_rec(const CircleCollider &a, core::Position2D &a_pos, CollisionInfo& a_info,
+                                          const Collider &b, core::Position2D &b_pos, CollisionInfo& b_info) {
+            float recCenterX = b_pos.value.x + b.bounds.x + b.bounds.width / 2.0f;
+            float recCenterY = b_pos.value.y + b.bounds.y + b.bounds.height / 2.0f;
 
-            float halfWidth = b->bounds.width / 2.0f;
-            float halfHeight = b->bounds.height / 2.0f;
+            float halfWidth = b.bounds.width / 2.0f;
+            float halfHeight = b.bounds.height / 2.0f;
 
-            float dx = a_pos->value.x - recCenterX;
-            float dy = a_pos->value.y - recCenterY;
+            float dx = a_pos.value.x - recCenterX;
+            float dy = a_pos.value.y - recCenterY;
 
             float absDx = fabsf(dx);
             float absDy = fabsf(dy);
 
             Vector2 overlap = {0, 0};
 
-            if (absDx > (halfWidth + a->radius)) return overlap;
-            if (absDy > (halfHeight + a->radius)) return overlap;
+            if (absDx > (halfWidth + a.radius)) return overlap;
+            if (absDy > (halfHeight + a.radius)) return overlap;
 
             if (absDx <= halfWidth || absDy <= halfHeight) {
                 // Side collision — resolve with axis-aligned MTV
-                float overlapX = (halfWidth + a->radius) - absDx;
-                float overlapY = (halfHeight + a->radius) - absDy;
+                float overlapX = (halfWidth + a.radius) - absDx;
+                float overlapY = (halfHeight + a.radius) - absDy;
 
 
                 if (overlapX < overlapY) {
@@ -94,7 +94,7 @@ namespace physics {
             float cornerDy = absDy - halfHeight;
 
             float cornerDistSq = cornerDx * cornerDx + cornerDy * cornerDy;
-            float radius = a->radius;
+            float radius = a.radius;
 
             if (cornerDistSq < radius * radius) {
                 //std::cout << "collided 2" << std::endl;

--- a/src/modules/engine/physics/physics_module.h
+++ b/src/modules/engine/physics/physics_module.h
@@ -29,8 +29,6 @@ namespace physics {
     inline flecs::system m_collision_detection_spatial_ecs;
     inline flecs::system m_collision_detection_naive_system;
 
-    inline std::unordered_map<std::pair<long,long>, flecs::query<const core::Position2D, const Collider>, IdPairHash> m_cell_query;
-
     class PhysicsModule : public BaseModule<PhysicsModule> {
         friend class BaseModule<PhysicsModule>;
 

--- a/src/modules/engine/physics/queries.h
+++ b/src/modules/engine/physics/queries.h
@@ -13,5 +13,6 @@
 namespace physics::queries {
     inline flecs::query<core::Position2D, Collider> visible_collision_bodies_query;
     inline flecs::query<core::Position2D, Collider> box_collider_query;
+
 }
 #endif //PHYSICS_QUERIES_H

--- a/src/modules/engine/physics/systems/collision_detection_relationship_spatial_hashing_system.h
+++ b/src/modules/engine/physics/systems/collision_detection_relationship_spatial_hashing_system.h
@@ -1,0 +1,69 @@
+//
+// Created by laurent on 07/07/25.
+//
+
+#ifndef COLLISION_DETECTION_RELATIONSHIP_SPATIAL_HASHING_SYSTEM_H
+#define COLLISION_DETECTION_RELATIONSHIP_SPATIAL_HASHING_SYSTEM_H
+
+#include <flecs.h>
+
+#include "collision_detection_system.h"
+#include "modules/engine/core/components.h"
+#include "modules/engine/physics/components.h"
+
+namespace physics::systems {
+inline void collision_detection_relationship_spatial_hashing_system(flecs::iter &it, size_t i, CollisionRecordList &list, SpatialHashingGrid &grid,
+                         GridCell &cell) {
+
+                    flecs::entity current_cell = it.entity(i);
+                    auto cur_q = it.world().query_builder<const core::Position2D, const Collider>().with<ContainedIn>(current_cell).filter();
+
+                    std::vector<CollisionRecord> collisions;
+                    for (int offset_y = -1; offset_y <= 1; offset_y++) {
+                        for (int offset_x = -1; offset_x <= 1; offset_x++) {
+                            int x = cell.x + offset_x;
+                            int y = cell.y + offset_y;
+                            if (!grid.cells.contains(std::make_pair(x, y))) continue;
+
+                            auto pair = std::make_pair(x, y);
+                            flecs::entity neighbour_cell = grid.cells[pair];
+
+                            auto other_q = it.world().query_builder<const core::Position2D, const Collider>().with<ContainedIn>(neighbour_cell).filter();
+
+                            cur_q.each([&](
+                            flecs::iter &self_it, size_t self_i, const core::Position2D &pos,
+                            const Collider &collider) {
+                                    flecs::entity self = self_it.entity(self_i);
+                                    other_q.each([&](flecs::iter &other_it, size_t other_i,
+                                                                const core::Position2D &other_pos,
+                                                                const Collider &other_collider) {
+                                        flecs::entity other = other_it.entity(other_i);
+                                        if (other.id() <= self.id()) return;
+
+                                        if ((collider.collision_filter & other_collider.collision_type) == none) return;
+
+                                        Rectangle self_rec = {
+                                            pos.value.x + collider.bounds.x, pos.value.y + collider.bounds.y,
+                                            collider.bounds.width,
+                                            collider.bounds.height
+                                        };
+                                        Rectangle other_rec = {
+                                            other_pos.value.x + other_collider.bounds.x,
+                                            other_pos.value.y + other_collider.bounds.y,
+                                            other_collider.bounds.width, other_collider.bounds.height
+                                        };
+
+                                        if (CheckCollisionRecs(self_rec, other_rec)) {
+                                            collisions.push_back({self, other});
+                                        }
+                                    });
+                                });
+                        }
+                    }
+                    if (collisions.empty()) return;
+                    list_mutex.lock();
+                    list.records.insert(list.records.end(), collisions.begin(), collisions.end());
+                    list_mutex.unlock();
+                }
+}
+#endif //COLLISION_DETECTION_RELATIONSHIP_SPATIAL_HASHING_SYSTEM_H

--- a/src/modules/engine/physics/systems/collision_detection_spatial_hashing_system.h
+++ b/src/modules/engine/physics/systems/collision_detection_spatial_hashing_system.h
@@ -1,0 +1,64 @@
+//
+// Created by laurent on 07/07/25.
+//
+
+#ifndef COLLISION_DETECTION_SPATIAL_HASHING_SYSTEM_H
+#define COLLISION_DETECTION_SPATIAL_HASHING_SYSTEM_H
+
+#include <flecs.h>
+
+#include "collision_detection_system.h"
+#include "modules/engine/core/components.h"
+#include "modules/engine/physics/components.h"
+
+namespace physics::systems {
+    inline void collision_detection_spatial_hashing_system(flecs::entity e, CollisionRecordList &list, SpatialHashingGrid &grid, GridCell &cell) {
+                    std::vector<CollisionRecord> collisions;
+                    for (int offset_y = -1; offset_y <= 1; offset_y++) {
+                        for (int offset_x = -1; offset_x <= 1; offset_x++) {
+                            int x = cell.x + offset_x;
+                            int y = cell.y + offset_y;
+                            if (!grid.cells.contains(std::make_pair(x, y))) continue;
+
+                            const GridCell neighbour = grid.cells[std::make_pair(x, y)].get<GridCell>();
+
+                            for (int i = 0; i < cell.entities.size(); i++) {
+                                flecs::entity self = cell.entities[i];
+                                if (!self.is_alive()) continue;
+                                const core::Position2D pos = cell.entities[i].get<core::Position2D>();
+                                const Collider collider = cell.entities[i].get<Collider>();
+                                for (int j = 0; j < neighbour.entities.size(); j++) {
+                                    flecs::entity other = neighbour.entities[j];
+                                    if (!other.is_alive()) continue;
+                                    const core::Position2D other_pos = neighbour.entities[j].get<core::Position2D>();
+                                    const Collider other_collider = neighbour.entities[j].get<Collider>();
+                                    if (self.id() <= other.id()) continue;
+
+                                    if ((collider.collision_filter & other_collider.collision_type) == none) continue;
+
+                                    Rectangle self_rec = {
+                                        pos.value.x + collider.bounds.x, pos.value.y + collider.bounds.y,
+                                        collider.bounds.width,
+                                        collider.bounds.height
+                                    };
+                                    Rectangle other_rec = {
+                                        other_pos.value.x + other_collider.bounds.x,
+                                        other_pos.value.y + other_collider.bounds.y,
+                                        other_collider.bounds.width, other_collider.bounds.height
+                                    };
+
+                                    if (CheckCollisionRecs(self_rec, other_rec)) {
+                                        //std::cout << "Collision detected" << std::endl;
+                                        collisions.push_back({self, other});
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (collisions.empty()) return;
+                    list_mutex.lock();
+                    list.records.insert(list.records.end(), collisions.begin(), collisions.end());
+                    list_mutex.unlock();
+                }
+}
+#endif //COLLISION_DETECTION_SPATIAL_HASHING_SYSTEM_H

--- a/src/modules/engine/physics/systems/collision_resolution_system.h
+++ b/src/modules/engine/physics/systems/collision_resolution_system.h
@@ -45,8 +45,8 @@ namespace physics::systems {
             b_move_ratio = 0.0f;
         }
 
-        a_pos->value = a_pos->value - overlap * a_move_ratio * 0.9;
-        b_pos->value = b_pos->value + overlap * b_move_ratio * 0.9;
+        a_pos->value = a_pos->value - overlap * a_move_ratio * 0.75;
+        b_pos->value = b_pos->value + overlap * b_move_ratio * 0.75;
     }
 
     /**
@@ -180,24 +180,28 @@ namespace physics::systems {
     };
 
     inline void collision_resolution_system(CollisionRecordList &rec) {
-        for (auto &record: rec.records) {
-            flecs::entity a = record.a; // Current entity
-            flecs::entity b = record.b; // Colliding entity
+        // looping helps with stability
+        for (int i = 0; i < 3; i++) {
+            for (auto &record: rec.records) {
+                flecs::entity a = record.a; // Current entity
+                flecs::entity b = record.b; // Colliding entity
 
-            const Collider *a_col = a.get<Collider>();
-            const Collider *b_col = b.get<Collider>();
+                const Collider *a_col = a.get<Collider>();
+                const Collider *b_col = b.get<Collider>();
 
-            // are the entities colliding?
-            CollisionInfo a_info;
-            CollisionInfo b_info;
-            if (!collision_handler[a_col->type][b_col->type](a, a_col, a_info, b, b_col, b_info)) continue;
+                // are the entities colliding?
+                CollisionInfo a_info;
+                CollisionInfo b_info;
+                if (!collision_handler[a_col->type][b_col->type](a, a_col, a_info, b, b_col, b_info)) continue;
 
-            // if the entities are of different types (player & enemy) we report it a significant collision
-            // enemy vs environment should not be significant. (too many tables)
-            // But player vs environment should count (because of projectiles, they might have behaviours specific to obstacles)
-            if ((a_col->collision_type & b_col->collision_type) == none &&
-                (a_col->collision_type | b_col->collision_type) != (enemy | environment)) {
-                rec.significant_collisions.push_back({a, b,a_info, b_info});
+                // if the entities are of different types (player & enemy) we report it a significant collision
+                // enemy vs environment should not be significant. (too many tables)
+                // But player vs environment should count (because of projectiles, they might have behaviours specific to obstacles)
+                if (i > 0) continue;
+                if ((a_col->collision_type & b_col->collision_type) == none &&
+                    (a_col->collision_type | b_col->collision_type) != (enemy | environment)) {
+                    rec.significant_collisions.push_back({a, b, a_info, b_info});
+                }
             }
         }
     }

--- a/src/modules/engine/physics/systems/collision_resolution_system.h
+++ b/src/modules/engine/physics/systems/collision_resolution_system.h
@@ -25,8 +25,8 @@ namespace physics::systems {
      */
     inline void correct_positions(flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
                                   const Collider &b_col, CollisionInfo &b_info, Vector2 overlap) {
-        core::Position2D a_pos = a.get_mut<core::Position2D>();
-        core::Position2D b_pos = b.get_mut<core::Position2D>();
+        const core::Position2D& a_pos = a.get<core::Position2D>();
+        const core::Position2D& b_pos = b.get<core::Position2D>();
 
         float a_move_ratio = 0.5f;
         float b_move_ratio = 0.5f;
@@ -45,8 +45,11 @@ namespace physics::systems {
             b_move_ratio = 0.0f;
         }
 
-        a_pos.value = a_pos.value - overlap * a_move_ratio * 0.75;
-        b_pos.value = b_pos.value + overlap * b_move_ratio * 0.75;
+        a.set<core::Position2D>({a_pos.value - overlap * a_move_ratio * 0.75});
+        b.set<core::Position2D>({b_pos.value + overlap * b_move_ratio * 0.75});
+        //std::cout << overlap.x << "," << overlap.y << std::endl;
+        //std::cout << a_move_ratio << std::endl;
+        //std::cout << b_move_ratio << std::endl;
     }
 
     /**

--- a/src/modules/engine/physics/systems/collision_resolution_system.h
+++ b/src/modules/engine/physics/systems/collision_resolution_system.h
@@ -23,30 +23,30 @@ namespace physics::systems {
      * @param b_col entity 2 mutable position
      * @param overlap amount of overlap of the two entities
      */
-    inline void correct_positions(flecs::entity &a, const Collider *a_col, CollisionInfo &a_info, flecs::entity &b,
-                                  const Collider *b_col, CollisionInfo &b_info, Vector2 overlap) {
-        core::Position2D *a_pos = a.get_mut<core::Position2D>();
-        core::Position2D *b_pos = b.get_mut<core::Position2D>();
+    inline void correct_positions(flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
+                                  const Collider &b_col, CollisionInfo &b_info, Vector2 overlap) {
+        core::Position2D a_pos = a.get_mut<core::Position2D>();
+        core::Position2D b_pos = b.get_mut<core::Position2D>();
 
         float a_move_ratio = 0.5f;
         float b_move_ratio = 0.5f;
 
-        if (a_col->static_body) {
+        if (a_col.static_body) {
             a_move_ratio = 0;
             b_move_ratio = 1.0f;
         }
-        if (b_col->static_body) {
+        if (b_col.static_body) {
             a_move_ratio = 1.0f;
             b_move_ratio = 0;
         }
 
-        if ((!a_col->correct_position && !a_col->static_body) || (!b_col->correct_position && !b_col->static_body)) {
+        if ((!a_col.correct_position && !a_col.static_body) || (!b_col.correct_position && !b_col.static_body)) {
             a_move_ratio = 0.0f;
             b_move_ratio = 0.0f;
         }
 
-        a_pos->value = a_pos->value - overlap * a_move_ratio * 0.75;
-        b_pos->value = b_pos->value + overlap * b_move_ratio * 0.75;
+        a_pos.value = a_pos.value - overlap * a_move_ratio * 0.75;
+        b_pos.value = b_pos.value + overlap * b_move_ratio * 0.75;
     }
 
     /**
@@ -57,15 +57,15 @@ namespace physics::systems {
      * @param other_base_col circle 2 entity
      * @return if the circles collided
      */
-    inline bool handle_circle_circle(flecs::entity &a, const Collider *a_col, CollisionInfo &a_info, flecs::entity &b,
-                                     const Collider *b_col, CollisionInfo &b_info) {
-        Vector2 a_pos = a.get<core::Position2D>()->value;
-        Vector2 b_pos = b.get<core::Position2D>()->value;
+    inline bool handle_circle_circle(flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
+                                     const Collider &b_col, CollisionInfo &b_info) {
+        Vector2 a_pos = a.get<core::Position2D>().value;
+        Vector2 b_pos = b.get<core::Position2D>().value;
 
-        const CircleCollider *col = a.get<CircleCollider>();
-        const CircleCollider *other_col = b.get<CircleCollider>();
+        const CircleCollider col = a.get<CircleCollider>();
+        const CircleCollider other_col = b.get<CircleCollider>();
 
-        if (!CheckCollisionCircles(a_pos, col->radius, b_pos, other_col->radius)) {
+        if (!CheckCollisionCircles(a_pos, col.radius, b_pos, other_col.radius)) {
             return false;
         }
 
@@ -74,7 +74,7 @@ namespace physics::systems {
 
         correct_positions(a, a_col, a_info, b, b_col, b_info, overlap);
 
-        Vector2 contact_point = a_pos + b_info.normal * col->radius;
+        Vector2 contact_point = a_pos + b_info.normal * col.radius;
         a_info.contact_point = contact_point;
         b_info.contact_point = contact_point;
 
@@ -89,16 +89,15 @@ namespace physics::systems {
      * @param b_col box base collider
      * @return if there was a collision
      */
-    inline bool handle_circle_rec_collision(flecs::entity &a, const Collider *a_col, CollisionInfo &a_info,
-                                            flecs::entity &b,
-                                            const Collider *b_col, CollisionInfo &b_info) {
-        Vector2 a_pos = a.get<core::Position2D>()->value;
-        Vector2 b_pos = b.get<core::Position2D>()->value;
-        const CircleCollider *circle_col = a.get<CircleCollider>();
+    inline bool handle_circle_rec_collision(flecs::entity &a, const Collider &a_col, CollisionInfo &a_info,
+                                            flecs::entity &b, const Collider &b_col, CollisionInfo &b_info) {
+        Vector2 a_pos = a.get<core::Position2D>().value;
+        Vector2 b_pos = b.get<core::Position2D>().value;
+        const CircleCollider circle_col = a.get<CircleCollider>();
         if (!CheckCollisionCircleRec(
-            a_pos, circle_col->radius, {
-                b_pos.x + b_col->bounds.x, b_pos.y + b_col->bounds.y, b_col->bounds.width,
-                b_col->bounds.height
+            a_pos, circle_col.radius, {
+                b_pos.x + b_col.bounds.x, b_pos.y + b_col.bounds.y, b_col.bounds.width,
+                b_col.bounds.height
             })) {
             return false;
         }
@@ -109,7 +108,7 @@ namespace physics::systems {
 
         correct_positions(a, a_col, a_info, b, b_col, b_info, overlap);
 
-        Vector2 contact_point = a_pos + b_info.normal * circle_col->radius;
+        Vector2 contact_point = a_pos + b_info.normal * circle_col.radius;
         a_info.contact_point = contact_point;
         b_info.contact_point = contact_point;
 
@@ -124,17 +123,17 @@ namespace physics::systems {
      * @param b_col box 2 collider
      * @return if the boxes collided or not
      */
-    inline bool handle_boxes_collision(flecs::entity &a, const Collider *a_col, flecs::entity &b,
-                                       const Collider *b_col) {
-        Vector2 a_pos = a.get<core::Position2D>()->value;
-        Vector2 b_pos = b.get<core::Position2D>()->value;
+    inline bool handle_boxes_collision(flecs::entity &a, const Collider &a_col, flecs::entity &b,
+                                       const Collider &b_col) {
+        Vector2 a_pos = a.get<core::Position2D>().value;
+        Vector2 b_pos = b.get<core::Position2D>().value;
         if (!CheckCollisionRecs(
             {
-                a_pos.x + a_col->bounds.x, a_pos.y + a_col->bounds.y, a_col->bounds.width,
-                a_col->bounds.height
+                a_pos.x + a_col.bounds.x, a_pos.y + a_col.bounds.y, a_col.bounds.width,
+                a_col.bounds.height
             }, {
-                b_pos.x + b_col->bounds.x, b_pos.y + b_col->bounds.y, b_col->bounds.width,
-                b_col->bounds.height
+                b_pos.x + b_col.bounds.x, b_pos.y + b_col.bounds.y, b_col.bounds.width,
+                b_col.bounds.height
             })) {
             return false;
         }
@@ -143,8 +142,8 @@ namespace physics::systems {
         return true;
     }
 
-    using CollisionHandler = std::function<bool(flecs::entity &, const Collider *, CollisionInfo &, flecs::entity &,
-                                                const Collider *, CollisionInfo &)>;
+    using CollisionHandler = std::function<bool(flecs::entity &, const Collider &, CollisionInfo &, flecs::entity &,
+                                                const Collider &, CollisionInfo &)>;
 
     /**
      * Map for collision type handling, we point to the correct position in the array with the Collider type enum
@@ -153,26 +152,26 @@ namespace physics::systems {
         // Circle = 0
         {
             // Circle vs Circle
-            [](flecs::entity &a, const Collider *a_col, CollisionInfo &a_info, flecs::entity &b,
-               const Collider *b_col, CollisionInfo &b_info) {
+            [](flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
+               const Collider &b_col, CollisionInfo &b_info) {
                 return handle_circle_circle(a, a_col, a_info, b, b_col, b_info);
             },
             // Circle vs Box
-            [](flecs::entity &a, const Collider *a_col, CollisionInfo &a_info, flecs::entity &b,
-               const Collider *b_col, CollisionInfo &b_info) {
+            [](flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
+               const Collider &b_col, CollisionInfo &b_info) {
                 return handle_circle_rec_collision(a, a_col, a_info, b, b_col, b_info);
             },
         },
         // Box = 1
         {
             // Box vs Circle
-            [](flecs::entity &a, const Collider *a_col, CollisionInfo &a_info, flecs::entity &b,
-               const Collider *b_col, CollisionInfo &b_info) {
+            [](flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
+               const Collider &b_col, CollisionInfo &b_info) {
                 return handle_circle_rec_collision(b, b_col, b_info, a, a_col, a_info);
             },
             // Box vs Box
-            [](flecs::entity &a, const Collider *a_col, CollisionInfo &a_info, flecs::entity &b,
-               const Collider *b_col, CollisionInfo &b_info) {
+            [](flecs::entity &a, const Collider &a_col, CollisionInfo &a_info, flecs::entity &b,
+               const Collider &b_col, CollisionInfo &b_info) {
                 return handle_boxes_collision(a, a_col, b, b_col);
             },
         }
@@ -186,20 +185,20 @@ namespace physics::systems {
                 flecs::entity a = record.a; // Current entity
                 flecs::entity b = record.b; // Colliding entity
 
-                const Collider *a_col = a.get<Collider>();
-                const Collider *b_col = b.get<Collider>();
+                const Collider a_col = a.get<Collider>();
+                const Collider b_col = b.get<Collider>();
 
                 // are the entities colliding?
                 CollisionInfo a_info;
                 CollisionInfo b_info;
-                if (!collision_handler[a_col->type][b_col->type](a, a_col, a_info, b, b_col, b_info)) continue;
+                if (!collision_handler[a_col.type][b_col.type](a, a_col, a_info, b, b_col, b_info)) continue;
 
                 // if the entities are of different types (player & enemy) we report it a significant collision
                 // enemy vs environment should not be significant. (too many tables)
                 // But player vs environment should count (because of projectiles, they might have behaviours specific to obstacles)
                 if (i > 0) continue;
-                if ((a_col->collision_type & b_col->collision_type) == none &&
-                    (a_col->collision_type | b_col->collision_type) != (enemy | environment)) {
+                if ((a_col.collision_type & b_col.collision_type) == none &&
+                    (a_col.collision_type | b_col.collision_type) != (enemy | environment)) {
                     rec.significant_collisions.push_back({a, b, a_info, b_info});
                 }
             }

--- a/src/modules/engine/physics/systems/init_spatial_hashing_grid_system.h
+++ b/src/modules/engine/physics/systems/init_spatial_hashing_grid_system.h
@@ -1,0 +1,26 @@
+//
+// Created by laurent on 07/07/25.
+//
+
+#ifndef INIT_SPATIAL_HASHING_GRID_SYSTEM_H
+#define INIT_SPATIAL_HASHING_GRID_SYSTEM_H
+
+#include <flecs.h>
+
+#include "modules/engine/core/components.h"
+#include "modules/engine/physics/components.h"
+#include "modules/engine/physics/physics_module.h"
+
+namespace physics::systems {
+    inline void init_spatial_hashing_grid_system(flecs::iter &it, size_t i, SpatialHashingGrid &hashing_grid,
+                                                 core::GameSettings &settings) {
+        for (int y = -1; y < std::ceil((float) settings.window_height / (float) hashing_grid.cell_size) + 1;
+             y++) {
+            for (int x = -1; x < std::ceil(settings.window_width / hashing_grid.cell_size) + 1; x++) {
+                flecs::entity e = it.world().entity().set<GridCell>({x, y});
+                hashing_grid.cells[std::make_pair(x, y)] = e;
+            }
+        }
+    }
+}
+#endif //INIT_SPATIAL_HASHING_GRID_SYSTEM_H

--- a/src/modules/engine/physics/systems/update_cell_entities_system.h
+++ b/src/modules/engine/physics/systems/update_cell_entities_system.h
@@ -1,0 +1,28 @@
+//
+// Created by laurent on 07/07/25.
+//
+
+#ifndef UPDATE_CELL_ENTITIES_SYSTEM_H
+#define UPDATE_CELL_ENTITIES_SYSTEM_H
+
+#include <cmath>
+#include <flecs.h>
+
+#include "modules/engine/core/components.h"
+#include "modules/engine/physics/components.h"
+
+namespace physics::systems {
+    inline void update_cell_entities_system(flecs::entity e, SpatialHashingGrid &grid, Collider &col, core::Position2D &pos) {
+        int cell_pos_x = std::floor((pos.value.x - grid.offset.x) / grid.cell_size);
+        int cell_pos_y = std::floor((pos.value.y - grid.offset.y) / grid.cell_size);
+
+        if (!grid.cells.contains(std::make_pair(cell_pos_x, cell_pos_y))) {
+            return;
+        }
+
+        flecs::entity cell = grid.cells[std::make_pair(cell_pos_x, cell_pos_y)];
+        cell.get_mut<GridCell>().entities.push_back(e);
+        //e.add<ContainedIn>(cell);
+    }
+}
+#endif //UPDATE_CELL_ENTITIES_SYSTEM_H

--- a/src/modules/engine/physics/systems/update_grid_on_window_resized_system.h
+++ b/src/modules/engine/physics/systems/update_grid_on_window_resized_system.h
@@ -1,0 +1,31 @@
+//
+// Created by laurent on 07/07/25.
+//
+
+#ifndef UPDATE_GRID_ON_WINDOW_RESIZED_SYSTEM_H
+#define UPDATE_GRID_ON_WINDOW_RESIZED_SYSTEM_H
+
+#include <cmath>
+#include <flecs.h>
+
+#include "init_spatial_hashing_grid_system.h"
+#include "modules/engine/core/components.h"
+#include "modules/engine/physics/components.h"
+
+namespace physics::systems {
+    inline void reset_grid(flecs::iter &it, size_t i, SpatialHashingGrid &hashing_grid, core::GameSettings &settings) {
+        for (auto cell: hashing_grid.cells) {
+            cell.second.destruct();
+        }
+        hashing_grid.cells.clear();
+        init_spatial_hashing_grid_system(it, i, hashing_grid, settings);
+    }
+
+    inline void update_grid_on_window_resized_system(flecs::iter &it, size_t i, SpatialHashingGrid &hashing_grid,
+                                                     core::GameSettings &settings) {
+        if (IsWindowResized()) {
+            reset_grid(it, i, hashing_grid, settings);
+        }
+    }
+}
+#endif //UPDATE_GRID_ON_WINDOW_RESIZED_SYSTEM_H

--- a/src/modules/engine/physics/systems/update_grid_system.h
+++ b/src/modules/engine/physics/systems/update_grid_system.h
@@ -1,0 +1,25 @@
+//
+// Created by laurent on 07/07/25.
+//
+
+#ifndef UPDATE_GRID_SYSTEM_H
+#define UPDATE_GRID_SYSTEM_H
+
+#include <flecs.h>
+#include <raylib.h>
+#include <raymath.h>
+#include "modules/engine/physics/components.h"
+#include "modules/engine/rendering/components.h"
+
+
+namespace physics::systems {
+    inline void update_grid_system(flecs::iter &it, size_t i, SpatialHashingGrid &grid, rendering::TrackingCamera &cam,
+                         core::GameSettings &settings, GridCell &cell) {
+        grid.offset = cam.camera.target - Vector2{
+            settings.window_width / 2.0f, settings.window_height / 2.0f
+        };
+
+        cell.entities.clear();
+    }
+}
+#endif //UPDATE_GRID_SYSTEM_H

--- a/src/modules/engine/rendering/gui/components.h
+++ b/src/modules/engine/rendering/gui/components.h
@@ -83,6 +83,8 @@ namespace rendering::gui {
             this->vertical_anchor = vertical_anchor;
         };
     };
+
+    struct WindowResizedEvent{};
 }
 
 #endif //GUI_COMPONENTS_H

--- a/src/modules/engine/rendering/gui/gui_module.cpp
+++ b/src/modules/engine/rendering/gui/gui_module.cpp
@@ -49,7 +49,7 @@ namespace rendering::gui {
                 .each(systems::on_parent_rectangle_changed_observer);
 
         world.system<core::GameSettings>("Window Resized")
-                .kind<PreRender>()
+                .kind(flecs::PreFrame)
                 .each(systems::check_window_resized_system);
 
         world.system<const Panel, const Rectangle>("Draw Panel")

--- a/src/modules/engine/rendering/gui/systems/check_window_resized_system.h
+++ b/src/modules/engine/rendering/gui/systems/check_window_resized_system.h
@@ -12,7 +12,7 @@
 #include "modules/engine/core/components.h"
 
 namespace rendering::gui::systems {
-    inline void check_window_resized_system(core::GameSettings &settings) {
+    inline void check_window_resized_system(flecs::entity e, core::GameSettings &settings) {
         if (IsWindowResized()) {
             set_gui_canvas_size_system(settings);
 #ifdef EMSCRIPTEN

--- a/src/modules/engine/rendering/gui/systems/parent_rectangle_changed_observer.h
+++ b/src/modules/engine/rendering/gui/systems/parent_rectangle_changed_observer.h
@@ -17,27 +17,27 @@ namespace rendering::gui::systems {
 
         auto anchor = e.get<Anchor>();
 
-        Rectangle temp{*e.get<Rectangle>()};
-        switch (anchor->horizontal_anchor) {
+        Rectangle temp{e.get<Rectangle>()};
+        switch (anchor.horizontal_anchor) {
             case CENTER:
-                temp.x = anchor->position.x + parent.x + parent.width / 2;
+                temp.x = anchor.position.x + parent.x + parent.width / 2;
                 break;
             case RIGHT:
-                temp.x = anchor->position.x + parent.x + parent.width;
+                temp.x = anchor.position.x + parent.x + parent.width;
                 break;
             default:
-                temp.x = anchor->position.x + parent.x;
+                temp.x = anchor.position.x + parent.x;
                 break;
         }
-        switch (anchor->vertical_anchor) {
+        switch (anchor.vertical_anchor) {
             case MIDDLE:
-                temp.y = anchor->position.y + parent.y + parent.height / 2;
+                temp.y = anchor.position.y + parent.y + parent.height / 2;
                 break;
             case BOTTOM:
-                temp.y = anchor->position.y + parent.y + parent.height;
+                temp.y = anchor.position.y + parent.y + parent.height;
                 break;
             default:
-                temp.y = anchor->position.y + parent.y;
+                temp.y = anchor.position.y + parent.y;
                 break;
         }
         e.set<Rectangle>({temp});

--- a/src/modules/engine/rendering/gui/systems/set_gui_canvas_size_system.h
+++ b/src/modules/engine/rendering/gui/systems/set_gui_canvas_size_system.h
@@ -16,8 +16,8 @@ namespace rendering::gui::systems {
         GUIModule::gui_canvas.set<Rectangle>({
             0, 0, static_cast<float>(GetScreenWidth()), static_cast<float>(GetScreenHeight())
         });
-        settings.windowHeight = GetScreenHeight();
-        settings.windowWidth = GetScreenWidth();
+        settings.window_height = GetScreenHeight();
+        settings.window_width = GetScreenWidth();
     }
 }
 #endif //SET_GUI_CANVAS_SIZE_SYSTEM_H

--- a/src/modules/engine/rendering/systems/create_camera_system.h
+++ b/src/modules/engine/rendering/systems/create_camera_system.h
@@ -9,7 +9,7 @@
 namespace rendering::systems {
     inline void create_camera_system(TrackingCamera &camera) {
         if (!camera.target.is_alive()) return;
-        camera.camera.target = camera.target.get<core::Position2D>()->value;
+        camera.camera.target = camera.target.get<core::Position2D>().value;
         camera.camera.offset = {GetScreenWidth() / 2.0f, GetScreenHeight() / 2.0f};
         camera.camera.zoom = 1.0f;
         camera.camera.rotation = 0;

--- a/src/modules/engine/rendering/systems/determine_visible_entities_system.h
+++ b/src/modules/engine/rendering/systems/determine_visible_entities_system.h
@@ -11,9 +11,9 @@ namespace rendering::systems {
                                                   const core::GameSettings &settings,
                                                   const TrackingCamera& camera) {
         //if (!camera.target.is_alive()) return;
-        if (pos.value.x - camera.camera.target.x > settings.windowWidth * 1.05f + renderable.texture.width - camera.camera.offset.x|| pos.value.x - camera.camera.target.x + settings.windowWidth * 0.05f < -renderable.texture.
+        if (pos.value.x - camera.camera.target.x > settings.window_width * 1.05f + renderable.texture.width - camera.camera.offset.x|| pos.value.x - camera.camera.target.x + settings.window_width * 0.05f < -renderable.texture.
             width - camera.camera.offset.x ||
-            pos.value.y - camera.camera.target.y > settings.windowHeight * 1.05f + renderable.texture.height - camera.camera.offset.y || pos.value.y - camera.camera.target.y + settings.windowHeight * 0.05f < -renderable.texture
+            pos.value.y - camera.camera.target.y > settings.window_height * 1.05f + renderable.texture.height - camera.camera.offset.y || pos.value.y - camera.camera.target.y + settings.window_height * 0.05f < -renderable.texture
             .height - camera.camera.offset.y) {
             e.remove<Visible>();
         } else if (!e.has<Visible>()) {

--- a/src/modules/engine/rendering/systems/update_and_begin_camera_mode_system.h
+++ b/src/modules/engine/rendering/systems/update_and_begin_camera_mode_system.h
@@ -14,7 +14,7 @@ namespace rendering::systems {
     inline void update_and_begin_camera_mode_system(flecs::iter& it, size_t, TrackingCamera &camera, core::GameSettings &settings) {
         Vector2 pos = camera.camera.target;
         if (camera.target.is_alive()) {
-            pos = camera.target.get<core::Position2D>()->value;
+            pos = camera.target.get<core::Position2D>().value;
         };
         camera.camera.target = Vector2Lerp(camera.camera.target ,pos , it.delta_time() * 2.0f);
         camera.camera.offset.x = settings.window_width / 2.0f;

--- a/src/modules/engine/rendering/systems/update_and_begin_camera_mode_system.h
+++ b/src/modules/engine/rendering/systems/update_and_begin_camera_mode_system.h
@@ -17,8 +17,8 @@ namespace rendering::systems {
             pos = camera.target.get<core::Position2D>()->value;
         };
         camera.camera.target = Vector2Lerp(camera.camera.target ,pos , it.delta_time() * 2.0f);
-        camera.camera.offset.x = settings.windowWidth / 2.0f;
-        camera.camera.offset.y = settings.windowHeight / 2.0f;
+        camera.camera.offset.x = settings.window_width / 2.0f;
+        camera.camera.offset.y = settings.window_height / 2.0f;
         BeginMode2D(camera.camera);
     }
 

--- a/src/modules/gameplay/systems/projectile_bounce_collided_system.h
+++ b/src/modules/gameplay/systems/projectile_bounce_collided_system.h
@@ -19,7 +19,7 @@ namespace gameplay::systems {
     inline void projectile_bounce_collided_system(flecs::iter &it, size_t i, physics::CollisionRecordList &list, Bounce &bounce,
                          physics::Velocity2D &vel, rendering::Rotation& rotation) {
         flecs::entity other = it.pair(4).second();
-        if (other.get<physics::Collider>()->collision_type == physics::environment) {
+        if (other.get<physics::Collider>().collision_type == physics::environment) {
             physics::CollisionInfo info = list.collisions_info[{it.entity(i).id(), other.id()}];
             vel.value = Vector2Reflect(vel.value, info.normal);
             rotation.angle = Vector2Angle(Vector2{0,1}, Vector2Negate(vel.value)) * RAD2DEG;

--- a/src/modules/gameplay/systems/projectile_no_bounce_collided_system.h
+++ b/src/modules/gameplay/systems/projectile_no_bounce_collided_system.h
@@ -14,7 +14,7 @@
 namespace gameplay::systems {
     inline void projectile_no_bounce_collided_system(flecs::iter &it, size_t i) {
         flecs::entity other = it.pair(0).second();
-        if (other.get<physics::Collider>()->collision_type == physics::environment) {
+        if (other.get<physics::Collider>().collision_type == physics::environment) {
             it.entity(i).remove<physics::CollidedWith>(other);
             it.entity(i).add<core::DestroyAfterFrame>();
         }

--- a/src/modules/gameplay/systems/restart_cooldown_system.h
+++ b/src/modules/gameplay/systems/restart_cooldown_system.h
@@ -11,7 +11,7 @@
 namespace gameplay::systems {
     inline void restart_cooldown_system(flecs::entity e) {
         if (e.has<Cooldown>())
-            e.set<Cooldown>({e.get<Cooldown>()->value, 0.0f});
+            e.set<Cooldown>({e.get<Cooldown>().value, 0.0f});
     }
 }
 #endif //RESTART_COOLDOWN_SYSTEM_H

--- a/src/modules/gameplay/systems/spawn_enemies_around_screen_system.h
+++ b/src/modules/gameplay/systems/spawn_enemies_around_screen_system.h
@@ -20,13 +20,13 @@ namespace gameplay::systems {
             float factor = rand() % 2 - 1;
             float neg = rand() % 1 - 1;
             float randX = outside_side_switch
-                              ? neg * factor * settings.windowWidth
-                              : rand() % settings.windowWidth;
-            randX += camera.camera.target.x - camera.camera.offset.x;
+                              ? neg * factor * (settings.window_width + 200)
+                              : rand() % (settings.window_width + 200);
+            randX += camera.camera.target.x - camera.camera.offset.x - 100;
             float randY = outside_side_switch
-                              ? rand() % settings.windowHeight
-                              : neg * factor * settings.windowHeight;
-            randY += camera.camera.target.y - camera.camera.offset.y;
+                              ? rand() % (settings.window_height + 200)
+                              : neg * factor * (settings.window_height + 200);
+            randY += camera.camera.target.y - camera.camera.offset.y - 100;
             bool is_valid = true;
 
             physics::queries::box_collider_query.run([&](flecs::iter &it) {


### PR DESCRIPTION
Added two implementations of a spatial hashing grid.

the first is a singleton component, with cell components. the singleton keeps track of the cell entities, the cells keep track of what entities are contained in what cells.

The second is uses the singleton component and is "pure" ecs but is really not performant. Instead of storing the entities in the cells, we use an exclusive relationship to specify that entities are ContainedIn cells. This leads to a lot of fragmentation so if using this method then make sure that the cells are larger, as to reduce it as much as possible. Not sure that without fragmenting it would be faster though since all the entities in cells would be in the same table (no point in that case).

Upgraded to 4.1.0.
Tried to use DontFragment with our implementation, but there was some funkiness I have to check into. Projectiles would only collide once with enemies, then new projectiles hitting it would not interact.

I also considered implementing a quadtree since in most cases entities are not spread out uniformly (best case for spatial grid), it would probably increase performance. I will keep that for another time cause I really want to get some gameplay elements going.

